### PR TITLE
Fix the invalid JSON for some missions

### DIFF
--- a/lib/ros/tcpros/message.rb
+++ b/lib/ros/tcpros/message.rb
@@ -29,7 +29,10 @@ module ROS::TCPROS
       sio.rewind
       data = sio.read
       len = data.length
-      data = [len, data].pack("La#{len}")
+      len += 1 # it's BAD BAD, but we had last char cut. The * option doesn't cut it
+      # from the buffer, but as length is embedded into the message - it too short, and gets cut on the other side :/
+      data = [len, data].pack("La#{len}") # we COULD try A here - so that string (too long) - is space padded, rather then null padded
+      # data = [len, data].pack('La*')
       socket.write(data)
       data
     end


### PR DESCRIPTION
For some Disney missions we had an invalid JSON because last charater
was removed - the "}". With this hack it works. Also since the 'a'
option means that the string is null-padded to the given length,
the previously working missions would work too. Just the broken ones
would start working (at least that's what I saw in the test in sim)